### PR TITLE
add a query to retrieve taxon IDs for entities.

### DIFF
--- a/resources/sparql/taxonomy/ncbi-id.mustache
+++ b/resources/sparql/taxonomy/ncbi-id.mustache
@@ -1,0 +1,12 @@
+
+prefix obo: <http://purl.obolibrary.org/obo/>
+
+# Given a bio entity, return the NCBI taxonomy ID to which it belongs.
+select ("{{src-id}}" as ?entity_id) ?ncbi_id
+where {
+  <{{bio-id}}> obo:RO_0002162 ?ncbi_id
+}
+
+# Local Variables:
+# mode: sparql
+# End:

--- a/resources/sparql/taxonomy/ncbi-id.mustache
+++ b/resources/sparql/taxonomy/ncbi-id.mustache
@@ -1,10 +1,17 @@
 
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix owl: <http://www.w3.org/2002/07/owl#>
 prefix obo: <http://purl.obolibrary.org/obo/>
 
 # Given a bio entity, return the NCBI taxonomy ID to which it belongs.
 select ("{{src-id}}" as ?entity_id) ?ncbi_id
 where {
-  <{{bio-id}}> obo:RO_0002162 ?ncbi_id
+  # Our BIO entity is a subclass of a restriction ...
+  <{{bio-id}}> rdfs:subClassOf _:in_taxon_restriction .
+  # ... in particular, an `in taxon` property restriction ...
+  _:in_taxon_restriction owl:onProperty obo:RO_0002162 .
+  # ... the subject of which is the taxonomy ID.
+  _:in_taxon_restriction owl:someValuesFrom ?ncbi_id
 }
 
 # Local Variables:

--- a/src/kabob_query/sparql/taxonomy.clj
+++ b/src/kabob_query/sparql/taxonomy.clj
@@ -1,0 +1,13 @@
+
+(ns kabob-query.sparql.taxonomy
+  (:require [kabob-query.api :refer [define-interface-fn]]
+            [kabob-query.kb :refer [sparql-query]]
+            [kabob-query.sparql.id :refer [bio-id id->ice-uri]]
+            [kabob-query.template :refer [render]]))
+
+(define-interface-fn ncbi-id kb
+  [source-id]
+  (sparql-query kb
+                (render "sparql/taxonomy/ncbi-id"
+                        {:src-id source-id
+                         :bio-id (bio-id kb (id->ice-uri source-id (:iao-namespaces kb)))})))

--- a/test/kabob_query/sparql/taxonomy_test.clj
+++ b/test/kabob_query/sparql/taxonomy_test.clj
@@ -1,0 +1,19 @@
+
+(ns kabob-query.sparql.taxonomy-test
+  (:require [edu.ucdenver.ccp.kr.kb :refer [kb open]]
+            [kabob-query.core :refer [query]]
+            [kabob-query.kb :refer [sparql-query]]
+            [kabob-query.sparql.id :as id]
+            [kabob-query.sparql.protein :as p]
+            [kabob-query.test.util :refer [*result* collect]])
+  (:use [midje.sweet]))
+
+(binding [*result* (atom [])]
+  (facts
+    (fact (query "sparql/taxonomy/ncbi-id" ["uniprot:p123"] {} collect)
+      => nil)
+    (fact @*result*
+      => [])
+    (against-background
+      (#'kabob-query.kb/open-kb-impl {}) => (open (kb :sesame-mem))
+      (#'id/query:bioentity anything anything) => '[{?/id kbio/BIO_123}])))


### PR DESCRIPTION
Example:

```
>> java -jar target/kabob-query-0.1.0-SNAPSHOT-standalone.jar kabob-query/cli -q sparql/taxonomy/ncbi-id -a "[\"uniprot:J3KMH5\"]" -p "{:db-url \"http://amc-tantor.ucdenver.pvt:10035\" :repository-name \"kabob-dev\" :username \"user\" :password \"****\"}"
entity_id, ncbi_id
uniprot:J3KMH5, obo:NCBITaxon_10090
```
