### PR TITLE
Adding drug-to-target and target-to-drug queries

### DIFF
--- a/resources/sparql/drug/protein-targets.mustache
+++ b/resources/sparql/drug/protein-targets.mustache
@@ -1,0 +1,50 @@
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX ccp_obo_ext: <http://ccp.ucdenver.edu/obo/ext/>
+PREFIX franzOption_clauseReorderer: <franz:identity>
+
+# Given a drug accession, the following query returns
+# the bioentities that are targets of the drug, i.e. bioentities
+# to which the drug binds:
+
+select ("{{src-id}}" as ?ext_source_id)
+       (group_concat(?target_ice_id; separator = "{{separator}}") as ?target_ice_ids)
+{
+  ?drug_sc rdfs:subClassOf <{{bio-id}}> .
+
+  # the drug is part of a has_participant restriction
+  ?has_drug_as_participant_r owl:someValuesFrom ?drug_sc .
+  ?has_drug_as_participant_r owl:onProperty obo:RO_0000057 . # RO:has_participant
+
+  # there is an interaction that has_participant the drug
+  ?interaction rdfs:subClassOf ?has_drug_as_participant_r .
+  ?interaction rdfs:subClassOf* ccp_obo_ext:GO_MI_EXT_binding_or_direct_interaction .
+
+  # the drug must inhere the drug role (CHEBI:23888)
+  ?interaction rdfs:subClassOf ?realizes_drug_role_r .
+  ?realizes_drug_role_r owl:onProperty obo:BFO_0000055 . # BFO:realizes
+  ?realizes_drug_role_r owl:someValuesFrom ?drugrole .
+  ?drugrole rdfs:subClassOf obo:CHEBI_23888 .  # CHEBI:drug
+  ?drugrole rdfs:subClassOf ?inheres_in_r .
+  ?inheres_in_r owl:onProperty obo:RO_0000052 . # RO:inheres_in
+  ?inheres_in_r owl:someValuesFrom ?drug_sc .
+
+  # the interaction has another participant that is the target of the drug
+  ?interaction rdfs:subClassOf ?has_target_as_participant_r .
+  ?has_target_as_participant_r owl:onProperty obo:RO_0000057 . # RO:has_participant
+  ?has_target_as_participant_r owl:someValuesFrom ?target_sc .
+
+  # the target participant is a subclass of some bioentity
+  ?target_sc rdfs:subClassOf ?target_bioentity .
+  # the target bioentity is different from the drug bioentity
+  FILTER (?target_bioentity !=  <{{bio-id}}>) .
+
+  # the target ICE identifiers denote the target bioentity
+  ?target_ice_id obo:IAO_0000219 ?target_bioentity . # IAO:denotes
+
+}
+group by ?target_bioentity
+
+
+# Local Variables:
+# mode: sparql
+# End:

--- a/resources/sparql/label/bioentity-label.mustache
+++ b/resources/sparql/label/bioentity-label.mustache
@@ -1,0 +1,16 @@
+
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix owl: <http://www.w3.org/2002/07/owl#>
+prefix obo: <http://purl.obolibrary.org/obo/>
+
+# Given a bio entity, return the any and all labels that are
+# associated with it.
+select ("{{src-id}}" as ?entity_id) ?label
+where {
+  # labels are assigned to bio-entities using rdfs:label
+  <{{bio-id}}> rdfs:label ?label .
+}
+
+# Local Variables:
+# mode: sparql
+# End:

--- a/resources/sparql/protein/targeted-by-drug.mustache
+++ b/resources/sparql/protein/targeted-by-drug.mustache
@@ -1,0 +1,47 @@
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX ccp_obo_ext: <http://ccp.ucdenver.edu/obo/ext/>
+PREFIX franzOption_clauseReorderer: <franz:identity>
+
+# Given a protein accession, the following query returns
+# the drugs that target the protein, i.e. the drugs to which
+# the protein binds:
+
+select ("{{src-id}}" as ?ext_source_id)
+       (group_concat(?drug_ice_id; separator = "{{separator}}") as ?drug_ice_ids)
+{
+  ?target_sc rdfs:subClassOf <{{bio-id}}> .
+
+  # the target is a participant in an interaction
+  ?has_target_as_participant_r owl:someValuesFrom ?target_sc .
+  ?has_target_as_participant_r owl:onProperty obo:RO_0000057 . # RO:has_participant
+  ?interaction rdfs:subClassOf ?has_target_as_participant_r .
+
+  ?interaction rdfs:subClassOf* ccp_obo_ext:GO_MI_EXT_binding_or_direct_interaction .
+
+  # the interaction has another participant that the drug role inheres_in
+  ?interaction rdfs:subClassOf ?has_drug_as_participant_r .
+  ?has_drug_as_participant_r owl:onProperty obo:RO_0000057 . # RO:has_participant
+  ?has_drug_as_participant_r owl:someValuesFrom ?drug_sc .
+
+  # the drug must inhere the drug role (CHEBI:23888)
+  ?interaction rdfs:subClassOf ?realizes_drug_role_r .
+  ?realizes_drug_role_r owl:onProperty obo:BFO_0000055 . # BFO:realizes
+  ?realizes_drug_role_r owl:someValuesFrom ?drugrole .
+  ?drugrole rdfs:subClassOf obo:CHEBI_23888 .  # CHEBI:drug
+  ?drugrole rdfs:subClassOf ?inheres_in_r .
+  ?inheres_in_r owl:onProperty obo:RO_0000052 . # RO:inheres_in
+  ?inheres_in_r owl:someValuesFrom ?drug_sc .
+
+  # the drug in the interaction is subclass of the main
+  # kabob drug bioentity (to which IDs are linked)
+  ?drug_sc rdfs:subClassOf ?drug_bioentity .
+  FILTER (?drug_bioentity != <{{bio-id}}>)
+  ?drug_ice_id obo:IAO_0000219 ?drug_bioentity .
+
+  }
+group by ?drug_bioentity
+
+
+# Local Variables:
+# mode: sparql
+# End:

--- a/src/kabob_query/sparql/drug.clj
+++ b/src/kabob_query/sparql/drug.clj
@@ -1,0 +1,25 @@
+
+(ns kabob-query.sparql.drug
+  (:require [clojure.string :as s]
+            [kabob-query.api :refer [define-interface-fn separator separator-re]]
+            [kabob-query.kb :refer [sparql-query]]
+            [kabob-query.sparql.id :as id]
+            [kabob-query.template :refer [render]]))
+
+(defn ^{:private true} bio->ext
+  [id-list]
+  (let [ids (s/split id-list separator-re)
+        short-ids (sort (map id/ice-uri->id ids))]
+    (s/join separator short-ids)))
+
+(define-interface-fn protein-targets kb
+  [source-id]
+  (let [ice-uri (id/id->ice-uri source-id (:iao-namespaces kb))
+        [iao eid] (id/ext-id->parts source-id)]
+    (map #(dissoc (assoc % '?/ext_target_ids (bio->ext (get % '?/target_ice_ids)))
+                  '?/target_ice_ids)
+         (sparql-query kb
+                       (render "sparql/drug/protein-targets"
+                               {:src-id source-id
+                                :bio-id (id/bio-id kb ice-uri)
+                                :separator separator})))))

--- a/src/kabob_query/sparql/label.clj
+++ b/src/kabob_query/sparql/label.clj
@@ -1,0 +1,13 @@
+
+(ns kabob-query.sparql.label
+  (:require [kabob-query.api :refer [define-interface-fn]]
+            [kabob-query.kb :refer [sparql-query]]
+            [kabob-query.sparql.id :refer [bio-id id->ice-uri]]
+            [kabob-query.template :refer [render]]))
+
+(define-interface-fn bioentity-label kb
+  [source-id]
+  (sparql-query kb
+                (render "sparql/label/bioentity-label"
+                        {:src-id source-id
+                         :bio-id (bio-id kb (id->ice-uri source-id (:iao-namespaces kb)))})))

--- a/src/kabob_query/sparql/protein.clj
+++ b/src/kabob_query/sparql/protein.clj
@@ -39,3 +39,15 @@
                                {:src-id source-id
                                 :bio-id (id/bio-id kb ice-uri)
                                 :separator separator})))))
+
+(define-interface-fn targeted-by-drug kb
+  [source-id]
+  (let [ice-uri (id/id->ice-uri source-id (:iao-namespaces kb))
+        [iao eid] (id/ext-id->parts source-id)]
+    (map #(dissoc (assoc % '?/ext_drug_ids (bio->ext (get % '?/drug_ice_ids)))
+                  '?/drug_ice_ids)
+         (sparql-query kb
+                       (render "sparql/protein/targeted-by-drug"
+                               {:src-id source-id
+                                :bio-id (id/bio-id kb ice-uri)
+                                :separator separator})))))

--- a/test/kabob_query/sparql/drug_test.clj
+++ b/test/kabob_query/sparql/drug_test.clj
@@ -1,0 +1,21 @@
+
+(ns kabob-query.sparql.drug-test
+  (:require [edu.ucdenver.ccp.kr.kb :refer [kb open]]
+            [kabob-query.core :refer [query]]
+            [kabob-query.kb :refer [sparql-query]]
+            [kabob-query.sparql.id :as id]
+            [kabob-query.sparql.drug :as p]
+            [kabob-query.test.util :refer [*result* collect]])
+  (:use [midje.sweet]))
+
+(binding [*result* (atom [])]
+  (facts
+    (fact (query "sparql/drug/protein-targets" ["drugbank:db123"] {} collect)
+      => nil)
+    (fact @*result*
+      => '[{?/ext_target_ids ["uniprot:P01" "uniprot:P02" "uniprot:P03"]
+            ?/ext_source_id "drugbank:db123"}])
+    (against-background
+      (#'kabob-query.kb/open-kb-impl {}) => (open (kb :sesame-mem))
+      (#'id/query:bioentity anything anything) => '[{?/id kbio/BIO_123}]
+      (#'p/bio->ext anything) => ["uniprot:P01" "uniprot:P02" "uniprot:P03"])))

--- a/test/kabob_query/sparql/label_test.clj
+++ b/test/kabob_query/sparql/label_test.clj
@@ -1,0 +1,19 @@
+
+(ns kabob-query.sparql.label-test
+  (:require [edu.ucdenver.ccp.kr.kb :refer [kb open]]
+            [kabob-query.core :refer [query]]
+            [kabob-query.kb :refer [sparql-query]]
+            [kabob-query.sparql.id :as id]
+            [kabob-query.sparql.label :as p]
+            [kabob-query.test.util :refer [*result* collect]])
+  (:use [midje.sweet]))
+
+(binding [*result* (atom [])]
+  (facts
+    (fact (query "sparql/label/bioentity-label" ["uniprot:p123"] {} collect)
+      => nil)
+    (fact @*result*
+      => [])
+    (against-background
+      (#'kabob-query.kb/open-kb-impl {}) => (open (kb :sesame-mem))
+      (#'id/query:bioentity anything anything) => '[{?/id kbio/BIO_123}])))

--- a/test/kabob_query/sparql/protein_test.clj
+++ b/test/kabob_query/sparql/protein_test.clj
@@ -39,3 +39,15 @@
       (#'kabob-query.kb/open-kb-impl {}) => (open (kb :sesame-mem))
       (#'id/query:bioentity anything anything) => '[{?/id kbio/BIO_123}]
       (#'p/bio->ext anything) => ["uniprot:P01" "uniprot:P02" "uniprot:P03"])))
+
+(binding [*result* (atom [])]
+  (facts
+    (fact (query "sparql/protein/targeted-by-drug" ["uniprot:p123"] {} collect)
+      => nil)
+    (fact @*result*
+      => '[{?/ext_drug_ids ["drugbank:DB01" "drugbank:DB02" "drugbank:DB03"]
+            ?/ext_source_id "uniprot:p123"}])
+    (against-background
+      (#'kabob-query.kb/open-kb-impl {}) => (open (kb :sesame-mem))
+      (#'id/query:bioentity anything anything) => '[{?/id kbio/BIO_123}]
+      (#'p/bio->ext anything) => ["drugbank:DB01" "drugbank:DB02" "drugbank:DB03"])))


### PR DESCRIPTION
This pull request contains two new query templates for extracting:
1) the bioentity targets (proteins) for a given drug
2) the drugs that target a given bioentity (protein)

These queries are made possible by the recent revision of the DrugBank rules in the kabob project (See UCDenver-ccp/kabob#9)
